### PR TITLE
Add universal `all` method

### DIFF
--- a/src/raze/methods.cr
+++ b/src/raze/methods.cr
@@ -60,6 +60,38 @@ HTTP_METHODS_OPTIONS = %w(get post put patch delete options)
 
 {% end %}
 
+def all(path, &block : HTTP::Server::Context -> (HTTP::Server::Context | String | Int32 | Int64 | Bool | Nil))
+  raise "websocket path \"#{path}\" must start with a \"/\"" unless path.starts_with? "/"
+  stack = Raze::Stack.new(&block)
+  HTTP_METHODS_OPTIONS.each do |method|
+    Raze::ServerHandler::INSTANCE.add_stack method.upcase, path, stack
+  end
+end
+
+def all(path, middlewares : Array(Raze::Handler))
+  raise "websocket path \"#{path}\" must start with a \"/\"" unless path.starts_with? "/"
+  stack = Raze::Stack.new(middlewares)
+  HTTP_METHODS_OPTIONS.each do |method|
+    Raze::ServerHandler::INSTANCE.add_stack method.upcase, path, stack
+  end
+end
+
+def all(path, middlewares : Array(Raze::Handler), &block : HTTP::Server::Context -> (HTTP::Server::Context | String | Int32 | Int64 | Bool | Nil))
+  raise "websocket path \"#{path}\" must start with a \"/\"" unless path.starts_with? "/"
+  stack = Raze::Stack.new(middlewares, &block)
+  HTTP_METHODS_OPTIONS.each do |method|
+    Raze::ServerHandler::INSTANCE.add_stack method.upcase, path, stack
+  end
+end
+
+def all(path, *middlewares)
+  raise "websocket path \"#{path}\" must start with a \"/\"" unless path.starts_with? "/"
+  stack = Raze::Stack.new(*middlewares)
+  HTTP_METHODS_OPTIONS.each do |method|
+    Raze::ServerHandler::INSTANCE.add_stack method.upcase, path, stack
+  end
+end
+
 def all(path, *middlewares, &block : HTTP::Server::Context -> (HTTP::Server::Context | String | Int32 | Int64 | Bool | Nil))
   raise "path \"#{path}\" must start with a \"/\"" unless path.starts_with? "/"
   stack = Raze::Stack.new(*middlewares, &block)

--- a/src/raze/methods.cr
+++ b/src/raze/methods.cr
@@ -60,6 +60,14 @@ HTTP_METHODS_OPTIONS = %w(get post put patch delete options)
 
 {% end %}
 
+def all(path, *middlewares, &block : HTTP::Server::Context -> (HTTP::Server::Context | String | Int32 | Int64 | Bool | Nil))
+  raise "path \"#{path}\" must start with a \"/\"" unless path.starts_with? "/"
+  stack = Raze::Stack.new(*middlewares, &block)
+  HTTP_METHODS_OPTIONS.each do |method|
+    Raze::ServerHandler::INSTANCE.add_stack method.upcase, path, stack
+  end
+end
+
 def ws(path, &block : HTTP::WebSocket, HTTP::Server::Context -> Void)
   raise "websocket path \"#{path}\" must start with a \"/\"" unless path.starts_with? "/"
   stack = Raze::WebSocketStack.new(&block)

--- a/src/raze/static_file_indexer.cr
+++ b/src/raze/static_file_indexer.cr
@@ -12,7 +12,7 @@ class Raze::StaticFileIndexer
       return
     end
 
-    Dir.foreach "#{base_dir}#{directory}" do |f|
+    Dir.each_child "#{base_dir}#{directory}" do |f|
       next if f == "." || f == ".."
       if File.directory? "#{base_dir}#{directory}/#{f}"
         # only index directory itself if "dir_listing" is enabled


### PR DESCRIPTION
Adds an `all` macro which defines a route for all methods.