### PR TITLE
Use reuse_port to take advantage of all the cores

### DIFF
--- a/src/raze.cr
+++ b/src/raze.cr
@@ -48,6 +48,6 @@ module Raze
     end
 
     puts "\nlistening at localhost:" + config.port.to_s if config.logging
-    server.listen(reuse_port: true)
+    server.listen(reuse_port: config.reuse_port)
   end
 end

--- a/src/raze.cr
+++ b/src/raze.cr
@@ -48,6 +48,6 @@ module Raze
     end
 
     puts "\nlistening at localhost:" + config.port.to_s if config.logging
-    server.listen
+    server.listen(reuse_port: true)
   end
 end

--- a/src/raze/config.cr
+++ b/src/raze/config.cr
@@ -3,7 +3,7 @@ class Raze::Config
 
   property host = "0.0.0.0"
   property port = 7777
-  porperty reuse_port = false
+  property reuse_port = false
   property env = "development"
   property static_dir_listing = false
   property compress = true

--- a/src/raze/config.cr
+++ b/src/raze/config.cr
@@ -3,6 +3,7 @@ class Raze::Config
 
   property host = "0.0.0.0"
   property port = 7777
+  porperty reuse_port = false
   property env = "development"
   property static_dir_listing = false
   property compress = true


### PR DESCRIPTION
Crystal currently doesn’t support parallelism so making the port to be reused will allow to run multiple processes so we can take advantages from all the cores;)