### PR TITLE
Cache Static Radix Result

### DIFF
--- a/src/raze/helpers.cr
+++ b/src/raze/helpers.cr
@@ -44,7 +44,7 @@ module Raze::Helpers
         IO.copy(file, deflate)
       end
     elsif compression_type == "deflate"
-      Flate::Writer.new(ctx.response) do |deflate|
+      Flate::Writer.open(ctx.response) do |deflate|
         IO.copy(file, deflate)
       end
     end

--- a/src/raze/radix.cr
+++ b/src/raze/radix.cr
@@ -11,14 +11,18 @@ class Raze::Radix(T)
   end
 
   def find(path)
+    # if the route already has a cached result, use it
     if cached_result = @cached_results[path]?
       return cached_result
     end
 
     result = @tree.find(path)
+
+    # if the route has an associated stack and there are no dynamic params, cache it
     if result.found? && result.params.empty?
       @cached_results[path] = result
     end
+
     result
   end
 end

--- a/src/raze/radix.cr
+++ b/src/raze/radix.cr
@@ -1,0 +1,24 @@
+require "radix"
+
+class Raze::Radix(T)
+  def initialize
+    @tree = ::Radix::Tree(T).new
+    @cached_results = {} of String => ::Radix::Result(T)
+  end
+
+  def add(path, payload)
+    @tree.add path, payload
+  end
+
+  def find(path)
+    if cached_result = @cached_results[path]?
+      return cached_result
+    end
+
+    result = @tree.find(path)
+    if result.found? && result.params.empty?
+      @cached_results[path] = result
+    end
+    result
+  end
+end

--- a/src/raze/server_handler.cr
+++ b/src/raze/server_handler.cr
@@ -1,4 +1,5 @@
 require "./ext/context"
+require "./radix"
 
 # The main server handler.
 class Raze::ServerHandler
@@ -9,12 +10,12 @@ class Raze::ServerHandler
   getter tree
 
   def initialize
-    @tree = Radix::Tree(Raze::Stack).new
+    @tree = Raze::Radix(Raze::Stack).new
     @radix_paths = [] of String
   end
 
   def clear_tree
-    @tree = Radix::Tree(Raze::Stack).new
+    @tree = Raze::Radix(Raze::Stack).new
     @radix_paths = [] of String
   end
 
@@ -29,7 +30,7 @@ class Raze::ServerHandler
       #   (1) add the new radix path to a tree by itself, and
       #   (2) look up an existing path and it matches the new radix path
       # then less specific path (e.g. with a "*" or ":") is being defined after a more specific path
-      temp_tree = Radix::Tree(String).new
+      temp_tree = ::Radix::Tree(String).new
       temp_tree.add node, node
       temp_result = temp_tree.find existing_path
       if temp_result.found? && temp_result.payload == node

--- a/src/raze/stack.cr
+++ b/src/raze/stack.cr
@@ -4,7 +4,7 @@ class Raze::Stack
   # A sub tree is used in case this stack is indexed using a wildcard
   # For example, if there is one stack at the path "/hel**" and another at the
   # path "/hello", the latter would be in the subtree of the first
-  property tree : Radix::Tree(Raze::Stack) | Nil = nil
+  property tree : Raze::Radix(Raze::Stack) | Nil = nil
 
   def initialize(handlers : Array(Raze::Handler), &block : HTTP::Server::Context -> (HTTP::Server::Context | String | Int32 | Int64 | Bool | Nil))
     @middlewares = handlers
@@ -75,8 +75,8 @@ class Raze::Stack
 
   def add_sub_tree(stack, node, method, path)
     # add tree to the existing stack because there is some globbing going on
-    @tree = Radix::Tree(Raze::Stack).new unless tree?
-    sub_tree = @tree.as(Radix::Tree(Raze::Stack))
+    @tree = Raze::Radix(Raze::Stack).new unless tree?
+    sub_tree = @tree.as(Raze::Radix(Raze::Stack))
     # add stack to this sub tree
     sub_tree.add node, stack
     sub_tree.add(radix_path("HEAD", path), Raze::Stack.new() { |ctx| "" }) if method == "GET"

--- a/src/raze/websocket_server_handler.cr
+++ b/src/raze/websocket_server_handler.cr
@@ -11,7 +11,7 @@ class Raze::WebSocketServerHandler < HTTP::WebSocketHandler
   @radix_paths = [] of String
 
   def initialize(&@proc : HTTP::WebSocket, HTTP::Server::Context -> Void)
-    @tree = Radix::Tree(Raze::WebSocketStack).new
+    @tree = Raze::Radix(Raze::WebSocketStack).new
   end
 
   def add_stack(path, stack)
@@ -21,7 +21,7 @@ class Raze::WebSocketServerHandler < HTTP::WebSocketHandler
       #   (1) add the new radix path to a tree by itself, and
       #   (2) look up an existing path and it matches the new radix path
       # then less specific path (e.g. with a "*" or ":") is being defined after a more specific path
-      temp_tree = Radix::Tree(String).new
+      temp_tree = ::Radix::Tree(String).new
       temp_tree.add node, node
       temp_result = temp_tree.find existing_path
       if temp_result.found? && temp_result.payload == node
@@ -38,8 +38,8 @@ class Raze::WebSocketServerHandler < HTTP::WebSocketHandler
         existing_stack.concat stack
       else
         # add tree to the existing stack because there is some globbing going on
-        existing_stack.tree = Radix::Tree(Raze::WebSocketStack).new unless existing_stack.tree
-        sub_tree = existing_stack.tree.as(Radix::Tree(Raze::WebSocketStack))
+        existing_stack.tree = Raze::Radix(Raze::WebSocketStack).new unless existing_stack.tree
+        sub_tree = existing_stack.tree.as(Raze::Radix(Raze::WebSocketStack))
         # add stack to this sub tree
         sub_tree.add node, stack
       end

--- a/src/raze/websocket_stack.cr
+++ b/src/raze/websocket_stack.cr
@@ -5,7 +5,7 @@ class Raze::WebSocketStack
   # A sub tree is used in case this stack is indexed using a wildcard
   # For example, if there is one stack at the path "/hel**" and another at the
   # path "/hello", the latter would be in the subtree of the first
-  property tree : Radix::Tree(Raze::WebSocketStack) | Nil = nil
+  property tree : Raze::Radix(Raze::WebSocketStack) | Nil = nil
 
   def initialize(handlers : Array(Raze::WebSocketHandler), &block : HTTP::WebSocket, HTTP::Server::Context -> Void)
     @middlewares = handlers


### PR DESCRIPTION
Now all defined static routes (e.g. `/home` or `/api/v1/users` but **NOT** `/api/v1/users/:user_id`) will be cached after the lookup in the radix tree. This means that the Raze will not need to check if the route has an associated handler because it will already know.