### PR TITLE
Implement Raze::State for stronger storage typing

### DIFF
--- a/spec/state_spec.cr
+++ b/spec/state_spec.cr
@@ -1,0 +1,32 @@
+require "./spec_helper"
+
+class Custom
+end
+
+Raze.add_state_property custom : Custom = Custom.new
+
+describe "Raze::State" do
+  it "acts like a hash" do
+    state = Raze::State.new
+    state["foo"] = "bar"
+    state["baz"] = 1
+
+    state["foo"].should eq("bar")
+    state["baz"].should eq(1)
+  end
+
+  it "has basic defined properties" do
+    state = Raze::State.new
+
+    state.responds_to?(:"int=").should be_true
+    state.responds_to?(:"uint=").should be_true
+    state.responds_to?(:"string=").should be_true
+    state.responds_to?(:"float=").should be_true
+    state.responds_to?(:"bool=").should be_true
+  end
+
+  it "has a defined custom property" do
+    state = Raze::State.new
+    state.custom.should be_a(Custom)
+  end
+end

--- a/src/raze/ext/context.cr
+++ b/src/raze/ext/context.cr
@@ -1,11 +1,9 @@
 class HTTP::Server
   class Context
-    TYPE_MAP = [Nil, String, Int32, Int64, Float64, Bool]
+    getter params = {} of String => Nil | String | Int32 | Int64 | Float64 | Bool
 
     macro finished
-      alias StoreTypes = Union({{ *TYPE_MAP }})
-      getter params = {} of String => StoreTypes
-      getter state = {} of String => StoreTypes
+      getter state = Raze::State.new
     end
 
     def query

--- a/src/raze/macros.cr
+++ b/src/raze/macros.cr
@@ -2,18 +2,6 @@ require "kilt"
 
 # halt_plain, halt_json, halt_html
 
-# Extends context storage with user defined types.
-#
-# class User
-#   property name
-# end
-#
-# add_context_storage_type(User)
-#
-macro add_context_storage_type(type)
-  {{ HTTP::Server::Context::STORE_MAPPINGS.push(type) }}
-end
-
 macro render(filename)
   Kilt.render({{filename}})
 end

--- a/src/raze/state.cr
+++ b/src/raze/state.cr
@@ -1,0 +1,45 @@
+module Raze
+  # `State` is an empty class used for carrying values across middleware
+  # through a route's execution. By default it acts as a hash to store
+  # common data types by a string key.
+  # ```
+  # ctx.state["foo"] = "bar"
+  # ctx.state["foo"] # "bar"
+  # ```
+  # You can add custom containers for any type by using the `add_state_property` macro.
+  # ```
+  # Raze.add_state_property user : UserModel
+  # # Later, in a middleware or route..
+  # ctx.state.user # UserModel
+  #```
+  class State
+    @values = {} of String => Nil | String | Int32 | Int64 | Float64 | Bool
+
+    property int : Int16 | Int32 | Int64 | Nil
+    property uint : UInt16 | UInt32 | UInt64  | Nil
+    property string : String?
+    property float : Float32 | Float64 | Nil
+    property bool : Bool?
+
+    def [](key)
+      @values[key]
+    end
+
+    def []?(key)
+      @values[key]?
+    end
+
+    def []=(key, value)
+      @values[key] = value
+    end
+  end
+
+  # Adds a custom `property` to the `State` class by reopening.
+  macro add_state_property(*props)
+    class ::Raze::State
+      {% for prop in props %}
+        property {{prop}}
+      {% end %}
+    end
+  end
+end


### PR DESCRIPTION
A "proof of concept" for what my rambling #9 would look like.

Notes:
- I maintain the *basic* hash-like interface, so this should not be a breaking change for anyone that *doesn't* use `add_storage_context_type`.
- I add some basic properties to `State` that reflect the basic type union, so you can use those instead and only have to deal with `T | Nil` instead of `Nil | String | Int32 | Int64 | Float64 | Bool`
- I see that `params` used the same type pool, `StoreTypes`, that is expanded by the original `add_storage_context_type` macro. However, I'm unsure what this means in terms of HTTP params.. I kept the basic type union for this for now. We could still do this by renaming my `Raze::State` to `Raze::Storage` and have:
```cr
getter state = Raze::Storage.new
getter params = Raze::Storage.new
```
- Unrelated to this PR (kind of): I might note that using `ctx.params=`, someone might pass custom objects to `URI.unescape(val)` because the type would support it - I don't think this works as stdlib defines `URI.unescape(string : String..)`. `parameters` should probably be restricted to `Hash(String, String)` I think for better debugging. Or maybe just `URI.unescape(val.to_s)`.

I also saw your note, if I recall, to move away from global macros like `get` etc. and have `Raze.get`-  this is a :+1:  from me and I reflect this TODO here, but I'll move it back to global if you would like.

I might alternatively suggest `Raze.state_property` instead of `add_..`; that's just me though.